### PR TITLE
Bump allowed versions of phpbu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "illuminate/support": "5.*",
         "illuminate/console": "5.*",
-        "phpbu/phpbu": "~5.0"
+        "phpbu/phpbu": "~5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Allow versions greater than `5.0` of `phpbu` (because, as of now, current version is `5.2.8`).